### PR TITLE
feat: enable API rate limit for all requests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   extends: [
     "eslint:recommended",
+    "plugin:security/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
     "prettier",
@@ -20,7 +21,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: "module",
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "security"],
   rules: {},
   ignorePatterns: ["dist"],
 };

--- a/app.ts
+++ b/app.ts
@@ -1,12 +1,14 @@
-import createError from "http-errors";
+import config from "config";
 import express, { ErrorRequestHandler } from "express";
-import * as path from "path";
-import cookieParser from "cookie-parser";
-
-import { loggerMiddleware, errorLoggerMiddleware } from "./shared/logger";
+import rateLimit from "express-rate-limit";
+import createError from "http-errors";
 
 import indexRouter from "./routes/index";
 import usersRouter from "./routes/users";
+
+import cookieParser from "cookie-parser";
+
+import { loggerMiddleware, errorLoggerMiddleware } from "./shared/logger";
 
 const app = express();
 
@@ -25,8 +27,14 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
+app.use(
+  rateLimit({
+    windowMs: config.get<number>("server.rateLimit.windowMs"),
+    max: config.get<number>("server.rateLimit.max"),
+  }),
+);
 app.use("/", indexRouter);
-app.use("/users", usersRouter);
+app.use("/user", usersRouter);
 
 // catch 404 and forward to error handler
 app.use((_req, _res, next) => next(createError(404)));

--- a/config/default.js
+++ b/config/default.js
@@ -6,6 +6,11 @@ module.exports = {
   },
   server: {
     port: 3000,
+    // https://github.com/nfriedly/express-rate-limit
+    rateLimit: {
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    },
   },
   log: {
     level: "info",

--- a/package-lock.json
+++ b/package-lock.json
@@ -877,6 +877,15 @@
         "@types/serve-static": "*"
       }
     },
+    "@types/express-rate-limit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/express-rate-limit/-/express-rate-limit-3.3.3.tgz",
+      "integrity": "sha512-Ys93gQSxRTTvIvUOvGk1dYeHTLqnRfLbZzSu+np6fViL/R3veFyCimMz9bjAWnfzR6InP8LphMnB/p3d7ZkSiQ==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/express-serve-static-core": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
@@ -2738,6 +2747,15 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-plugin-security": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",
+      "integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
+      "dev": true,
+      "requires": {
+        "safe-regex": "^1.1.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -2975,6 +2993,11 @@
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
         }
       }
+    },
+    "express-rate-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.0.0.tgz",
+      "integrity": "sha512-dhT57wqxfqmkOi4HM7NuT4Gd7gbUgSK2ocG27Y6lwm8lbOAw9XQfeANawGq8wLDtlGPO1ZgDj0HmKsykTxfFAg=="
     },
     "express-winston": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "build": "run-s remove-dist build-tsc copy-static install-prod-deps"
   },
   "dependencies": {
-    "config": "^3.2.5",
     "@types/got": "^9.6.9",
+    "config": "^3.2.5",
     "cookie-parser": "~1.4.4",
     "debug": "~4.1.1",
     "express": "~4.17.1",
+    "express-rate-limit": "^5.0.0",
     "express-winston": "^4.0.2",
-    "http-errors": "~1.7.3",
     "got": "^10.2.2",
     "http-errors": "~1.7.3",
     "winston": "^3.2.1"
@@ -51,6 +51,7 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.2",
+    "@types/express-rate-limit": "^3.3.3",
     "@types/fs-extra": "^8.0.1",
     "@types/http-errors": "^1.6.3",
     "@types/jest": "^24.9.0",
@@ -62,6 +63,7 @@
     "@typescript-eslint/parser": "^2.16.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.9.0",
+    "eslint-plugin-security": "^1.4.0",
     "fs-extra": "^8.1.0",
     "husky": "^4.0.10",
     "jest": "^24.9.0",


### PR DESCRIPTION
In order to avoid brute force requests, or DoS requests.
Enable basic rate limit for all requests made to the server.